### PR TITLE
fix: time zone filter

### DIFF
--- a/src/helpers/dateHelper.ts
+++ b/src/helpers/dateHelper.ts
@@ -9,9 +9,8 @@ type PeriodReport = {
 }
 
 export function adjustTimeZone(data: Date) {
-    data.setHours(data.getHours() + 3);
-
-    return data;
+    
+   return data.setHours(data.getHours() + 3);
 }
 
 export function getCurrentDateString() {

--- a/src/helpers/dateHelper.ts
+++ b/src/helpers/dateHelper.ts
@@ -8,8 +8,7 @@ type PeriodReport = {
     mounth: string;
 }
 
-export function adjustTimeZone(data: Date) {
-    
+export function adjustSupabaseTimeZone(data: Date) {
    return data.setHours(data.getHours() + 3);
 }
 

--- a/src/helpers/dateHelper.ts
+++ b/src/helpers/dateHelper.ts
@@ -8,8 +8,11 @@ type PeriodReport = {
     mounth: string;
 }
 
-export function adjustSupabaseTimeZone(data: Date) {
-   return data.setHours(data.getHours() + 3);
+export function adjustDatabaseTimeZone(stringDate: string) {
+    const DATABASE_TIME_ZONE_DIFFERENCE = 3;
+    let newDate = new Date(stringDate)
+    newDate.setHours(newDate.getHours() + DATABASE_TIME_ZONE_DIFFERENCE);
+    return newDate
 }
 
 export function getCurrentDateString() {

--- a/src/helpers/dateHelper.ts
+++ b/src/helpers/dateHelper.ts
@@ -8,6 +8,12 @@ type PeriodReport = {
     mounth: string;
 }
 
+export function adjustTimeZone(data: Date) {
+    data.setHours(data.getHours() + 3);
+
+    return data;
+}
+
 export function getCurrentDateString() {
     const currentDate = new Date();
     const year = currentDate.getFullYear();

--- a/src/pages/api/report/get-all.ts
+++ b/src/pages/api/report/get-all.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { Prisma } from "@prisma/client";
 import { IReportItem } from "@/interfaces/reports/IReportItem";
 import { ReportFilterOptions } from "@/interfaces/reports/types/reportFilterOptions";
-import { adjustSupabaseTimeZone } from "@/helpers/dateHelper";
+import { adjustDatabaseTimeZone } from "@/helpers/dateHelper";
 
 export default async function handler(
     req: NextApiRequest,
@@ -17,8 +17,8 @@ export default async function handler(
 
     try {
         const userId = req.query.userId as string;
-        const startDate = adjustSupabaseTimeZone(new Date(req.query.startDate as string))
-        const endDate = adjustSupabaseTimeZone(new Date(req.query.endDate as string))
+        const startDate = adjustDatabaseTimeZone(req.query.startDate as string)
+        const endDate = adjustDatabaseTimeZone(req.query.endDate as string)
         const option = req.query.option as ReportFilterOptions;
         const searchName = req.query.searchName as string;
 

--- a/src/pages/api/report/get-all.ts
+++ b/src/pages/api/report/get-all.ts
@@ -4,6 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { Prisma } from "@prisma/client";
 import { IReportItem } from "@/interfaces/reports/IReportItem";
 import { ReportFilterOptions } from "@/interfaces/reports/types/reportFilterOptions";
+import { adjustTimeZone } from "@/helpers/dateHelper";
 
 export default async function handler(
     req: NextApiRequest,
@@ -16,8 +17,8 @@ export default async function handler(
 
     try {
         const userId = req.query.userId as string;
-        const startDate = new Date(req.query.startDate as string)
-        const endDate = new Date(req.query.endDate as string)
+        const startDate = adjustTimeZone(new Date(req.query.startDate as string))
+        const endDate = adjustTimeZone(new Date(req.query.endDate as string))
         const option = req.query.option as ReportFilterOptions;
         const searchName = req.query.searchName as string;
 

--- a/src/pages/api/report/get-all.ts
+++ b/src/pages/api/report/get-all.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { Prisma } from "@prisma/client";
 import { IReportItem } from "@/interfaces/reports/IReportItem";
 import { ReportFilterOptions } from "@/interfaces/reports/types/reportFilterOptions";
-import { adjustTimeZone } from "@/helpers/dateHelper";
+import { adjustSupabaseTimeZone } from "@/helpers/dateHelper";
 
 export default async function handler(
     req: NextApiRequest,
@@ -17,8 +17,8 @@ export default async function handler(
 
     try {
         const userId = req.query.userId as string;
-        const startDate = adjustTimeZone(new Date(req.query.startDate as string))
-        const endDate = adjustTimeZone(new Date(req.query.endDate as string))
+        const startDate = adjustSupabaseTimeZone(new Date(req.query.startDate as string))
+        const endDate = adjustSupabaseTimeZone(new Date(req.query.endDate as string))
         const option = req.query.option as ReportFilterOptions;
         const searchName = req.query.searchName as string;
 


### PR DESCRIPTION
### PROBLEM
- New reports are not appearing due to the server time zone (England).


### SOLUTION
- Adjusts filter to take London time zone into account, this way the filter adds the current time plus 3 hours

